### PR TITLE
Add L9 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,6 @@
 name: run-tests
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,14 +1,13 @@
 name: run-tests
 
-on: [push, pull_request, workflow_dispatch]
+on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest]
         php: [8.0, 8.1]
         laravel: [8.*, 9.*]
         include:
@@ -18,7 +17,7 @@ jobs:
             testbench: 6.*
 
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.os }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,5 +41,6 @@ jobs:
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,6 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         php: [8.0, 8.1]
         laravel: [8.*, 9.*]
-        dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 9.*
             testbench: 7.*
@@ -22,7 +21,7 @@ jobs:
             php: 8.1
 
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
@@ -44,7 +43,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+          composer update --prefer-dist --no-interaction --no-suggest
 
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,14 +9,29 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [7.4]
-        laravel: [7.*, 8.*]
+        php: [7.4, 8.0, 8.1]
+        laravel: [7.*, 8.*, 9.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 9.*
+            testbench: 6.*
           - laravel: 8.*
             testbench: 6.*
           - laravel: 7.*
             testbench: 5.*
+        exclude:
+          - laravel: 9.*
+            testbench: 6.*
+            php: 7.4
+          - laravel: 8.*
+            testbench: 6.*
+            php: 7.4
+          - laravel: 7.*
+            testbench: 5.*
+            php: 8.0
+          - laravel: 7.*
+            testbench: 5.*
+            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,6 +17,10 @@ jobs:
             testbench: 7.*
           - laravel: 8.*
             testbench: 6.*
+        exclude:
+          - laravel: 8.*
+            php: 8.1
+
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,16 +21,10 @@ jobs:
             testbench: 5.*
         exclude:
           - laravel: 9.*
-            testbench: 6.*
-            php: 7.4
-          - laravel: 8.*
-            testbench: 6.*
             php: 7.4
           - laravel: 7.*
-            testbench: 5.*
             php: 8.0
           - laravel: 7.*
-            testbench: 5.*
             php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,16 +31,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Cache dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.composer/cache/files
           key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v1
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 9.*
-            testbench: 6.*
+            testbench: 7.*
           - laravel: 8.*
             testbench: 6.*
           - laravel: 7.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,9 +16,6 @@ jobs:
             testbench: 7.*
           - laravel: 8.*
             testbench: 6.*
-        exclude:
-          - laravel: 8.*
-            php: 8.1
 
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.os }}
@@ -43,7 +40,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          composer update --prefer-dist --no-interaction --no-suggest
+          composer update --no-interaction --no-suggest
 
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,23 +9,14 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [7.4, 8.0, 8.1]
-        laravel: [7.*, 8.*, 9.*]
+        php: [8.0, 8.1]
+        laravel: [8.*, 9.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 9.*
             testbench: 7.*
           - laravel: 8.*
             testbench: 6.*
-          - laravel: 7.*
-            testbench: 5.*
-        exclude:
-          - laravel: 9.*
-            php: 7.4
-          - laravel: 7.*
-            php: 8.0
-          - laravel: 7.*
-            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
-        "illuminate/support": "^5.8|^6.0|^7.0|^8.0|9.0"
+        "php": "^8.0",
+        "illuminate/support": "^8.0|9.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^4.0|^5.0|^6.0",
+        "orchestra/testbench": "^6.0|^7.0",
         "phpunit/phpunit": "^8.2|^9.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "^6.0|^7.0",
-        "phpunit/phpunit": "^8.2|^9.1"
+        "phpunit/phpunit": "~9.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "illuminate/support": "^5.8|^6.0|^7.0|^8.0"
+        "illuminate/support": "^5.8|^6.0|^7.0|^8.0|9.0"
     },
     "require-dev": {
         "orchestra/testbench": "^4.0|^5.0|^6.0",


### PR DESCRIPTION
Hey @Skullbock 

This PR adds support for Laravel 9 and PHP 8.1.  It's a breaking change as it also drops support for unsupported and EoL versions of laravel and PHP so you'd probably want to tag a new major release.

I had to fiddle around with (and ultimately strip back) a lot of the test matrix in the github workflow.  Some tests were failing due to various deprecations and the windows ones were not working due to a few extensions not being present.  I don't really have time to dig into that properly (plus I don't have a windows machine) so I've removed those options from the test matrix.  It's all green on ubuntu with different combinations of PHP 8/8.1 and Laravel 8 & 9.

Shout if you have any questions